### PR TITLE
update to Lean 3.4.1

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Sylow"
 version = "0.1"
-lean_version = "nightly-2018-04-20"
+lean_version = "3.4.1"
 path = "src"
 
 [dependencies]


### PR DESCRIPTION
This makes it so that the project works with `elan` and `leanproject`.